### PR TITLE
adds AR connection manager to stop map timeout after multiple requests

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -10,4 +10,6 @@ get "/" do
   File.read("public/index.html")
 end
 
+use ActiveRecord::ConnectionAdapters::ConnectionManagement
+
 run Sinatra::Application


### PR DESCRIPTION
I just remembered that I had this exact problem when hosting my MormonMapper site on heroku; the first few times the map would load fine, then I would get the same Internal Server Error. After an exhaustive search I discovered that using a simple ActiveRecord connection manager tool fixed the problem. As far as I know, it ensures that the connections to the database created every time a request is made are closed. AR can't handle too many connections at the same time, which is why it crashes after multiple loads of the map page. This middleware handles these connections, closing them when they are complete. Since Jesse is the Heroku meister for this project, I can't test it out on my end, but I'm very confident it'll fix the problem once we get this merged into master and redeployed on Heroku.
